### PR TITLE
ubuntu install update

### DIFF
--- a/documentation/SETUP.md
+++ b/documentation/SETUP.md
@@ -6,29 +6,31 @@
 
     ```
     apt-get update
-    apt-get install git -y
-    apt-get install unzip -y
-    sudo apt-get install python-setuptools python-dev build-essential -y
-    apt-get install libxml2-dev -y
-    apt-get install libxslt1-dev -y
-    easy_install -U setuptools
-    apt-get install python-pip
-    pip install lxml
-    pip install requests
+    apt-get install git unzip python-setuptools python-dev build-essential libxml2-dev libxslt1-dev libz-dev setuptools python-pip -y
     ```
 
 2. Clone this repo locally using the `git clone` command. This requires a Github account.
-   ```
-   git clone git@github.com:HHS/pillbox-data-process.git
-   ```
 
-3. Follow [steps for data process](https://github.com/HHS/pillbox-data-process/tree/master/scripts#pillbox-data-process).
+    ```
+    git clone git@github.com:HHS/pillbox-data-process.git
+    ```
+
+3. Install Python requirements for Pillbox
+
+    ```
+    cd pillbox-data-process
+    cd scripts
+    sudo pip install -r requirements.txt
+    ```
+
+4. Follow [steps for data process](https://github.com/HHS/pillbox-data-process/tree/master/scripts#pillbox-data-process).
 
 #### Setting up on Mac OSX
 
 Latest versions of OSX come with Python 2.7 installed. To run the Pillbox process, additional packages need to be installed. This assumes [Xcode](https://developer.apple.com/xcode/downloads/) & command line tools are installed. If not, install Xcode first.
 
 1. Install pip
+
     ```
     sudo easy_install pip
     ```
@@ -40,6 +42,7 @@ Latest versions of OSX come with Python 2.7 installed. To run the Pillbox proces
     ```
 
 3. Install Python requirements for Pillbox
+
     ```
     cd pillbox-data-process
     cd scripts


### PR DESCRIPTION
Just a little bit of cleanup on the install doc. I modified the ubuntu install instructions so that they also used requirements.txt (simplejson wasn't mentioned). I also put all the apt packages into one install line. 

I noticed that I needed to install libz-dev on Ubuntu 13.10 before I could build lxml. I got this error:

```
x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/libxml2 -I/home/ubuntu/.virtualenvs/pillbox/build/lxml/src/lxml/includes -I/usr/include/python2.7 -c src/lxml/lxml.etree.c -o build/temp.linux-x86_64-2.7/src/lxml/lxml.etree.o -w

x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security build/temp.linux-x86_64-2.7/src/lxml/lxml.etree.o -lxslt -lexslt -lxml2 -lz -lm -o build/lib.linux-x86_64-2.7/lxml/etree.so

/usr/bin/ld: cannot find -lz

collect2: error: ld returned 1 exit status

error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

----------------------------------------

Cleaning up...

  Removing temporary dir /home/ubuntu/.virtualenvs/pillbox/build...
Command /home/ubuntu/.virtualenvs/pillbox/bin/python -c "import setuptools;__file__='/home/ubuntu/.virtualenvs/pillbox/build/lxml/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-72GjJH-record/install-record.txt --single-version-externally-managed --install-headers /home/ubuntu/.virtualenvs/pillbox/include/site/python2.7 failed with error code 1 in /home/ubuntu/.virtualenvs/pillbox/build/lxml

Exception information:
Traceback (most recent call last):
  File "/home/ubuntu/.virtualenvs/pillbox/local/lib/python2.7/site-packages/pip/basecommand.py", line 134, in main
    status = self.run(options, args)
  File "/home/ubuntu/.virtualenvs/pillbox/local/lib/python2.7/site-packages/pip/commands/install.py", line 241, in run
    requirement_set.install(install_options, global_options, root=options.root_path)
  File "/home/ubuntu/.virtualenvs/pillbox/local/lib/python2.7/site-packages/pip/req.py", line 1298, in install
    requirement.install(install_options, global_options, *args, **kwargs)
  File "/home/ubuntu/.virtualenvs/pillbox/local/lib/python2.7/site-packages/pip/req.py", line 625, in install
    cwd=self.source_dir, filter_stdout=self._filter_install, show_stdout=False)
  File "/home/ubuntu/.virtualenvs/pillbox/local/lib/python2.7/site-packages/pip/util.py", line 670, in call_subprocess
    % (command_desc, proc.returncode, cwd))
InstallationError: Command /home/ubuntu/.virtualenvs/pillbox/bin/python -c "import setuptools;__file__='/home/ubuntu/.virtualenvs/pillbox/build/lxml/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-72GjJH-record/install-record.txt --single-version-externally-managed --install-headers /home/ubuntu/.virtualenvs/pillbox/include/site/python2.7 failed with error code 1 in /home/ubuntu/.virtualenvs/pillbox/build/lxml
```
