### PR TITLE
Changed Readme to fix program from exiting from makecsv.py

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,6 +36,8 @@ After the downloading is finished, to process the unzipped XML files, run `maste
 To run:
 
 ```
+cd scripts
+mkdir ../../api
 ./master.py
 ```
 


### PR DESCRIPTION
Fixed the readme to create the api directory manually without which the "makecsv.py" file exits with an error