### PR TITLE
Fix dead link to /documentation/DATA.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ This repository contains the code for that process. It is intended to begin to g
 
 ### Warning
 
-Pillbox's source data is known to have errors and inconsistencies. Read [this document](https://github.com/developmentseed/pillbox-data-api/blob/updates/documentation/DATA.md) before working with Pillbox's API, data, and images.
+Pillbox's source data is known to have errors and inconsistencies. Read [this document](https://github.com/HHS/pillbox-data-process/blob/master/documentation/DATA.md) before working with Pillbox's API, data, and images.
 
 [Read more about Pillbox](https://github.com/HHS/pillbox-data-process/blob/master/documentation/ABOUT.md).


### PR DESCRIPTION
As the project was renamed and moved to a different Github account the link in the README.md linking to DATA.md was dead, this fixes that.
I know this project is unmaintained, but it would still be nice if this could be merged to preserve this project for future viewers.